### PR TITLE
SYS-883 Parameters "password" and "Country" are optional when creating User

### DIFF
--- a/api/user.md
+++ b/api/user.md
@@ -52,7 +52,7 @@ Parameter    | Description
 ---          | ---
 `email`      | __Required.__
 `password`   | __Optional.__
-`country`    | _DE_ or _CH_ __Optional.__
+`country`    | _DE_ or _CH_ __Required.__
 `firstname`  | __Required.__
 `lastname`   | __Required.__
 `gender`     | _male_ or _female_. _Optional._

--- a/api/user.md
+++ b/api/user.md
@@ -51,8 +51,8 @@ Location: {{ site.parku.api }}/user
 Parameter    | Description
 ---          | ---
 `email`      | __Required.__
-`password`   | __Required.__
-`country`    | _DE_ or _CH_ __Required.__
+`password`   | __Optional.__
+`country`    | _DE_ or _CH_ __Optional.__
 `firstname`  | __Required.__
 `lastname`   | __Required.__
 `gender`     | _male_ or _female_. _Optional._

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ title: Changelog
 <!--
   Add new changes to the log in historically descending order.
 -->
+## {{ '2015-07-30' | date_to_string }}
+
+* Parameter "password" is optional when creating User
 
 ## {{ '2015-07-05' | date_to_string }}
 


### PR DESCRIPTION
I adapted the documentation to the live code regarding the password and country parameter when creating a new User. They haven't been required so far, but were marked as such. 